### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/iostore_uasset.rs
+++ b/src/iostore_uasset.rs
@@ -768,7 +768,7 @@ impl UObjectPropertyData {
                 }
             },
             Self::Float(val) => {
-                writer.write_all(format!("{val:.}\n").as_bytes()).unwrap();
+                writer.write_all(format!("{val}\n").as_bytes()).unwrap();
             },
             Self::String(val) => {
                 if val.is_empty() {
@@ -800,7 +800,7 @@ impl UObjectPropertyData {
                         Self::Int32(v) => v.to_string(),
                         Self::UInt16(v) => v.to_string(),
                         Self::String(v) => v.clone(),
-                        Self::Float(v) => format!("{v:.}"),
+                        Self::Float(v) => format!("{v}"),
                         Self::Byte(v) => format!("{v:x}"),
                         _ => panic!("Unprintable map key type: {key_type}")
                     };


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.